### PR TITLE
[fix] SSE handle initMessage

### DIFF
--- a/src/components/Alarm/Alarm.tsx
+++ b/src/components/Alarm/Alarm.tsx
@@ -1,9 +1,9 @@
 import { Link } from 'react-router-dom';
-import fetchSSE from '../../hooks/useSSE';
+import fetchSSEHandler from '../../handler/fetchSSEHandler';
 import styled from 'styled-components';
 
 export default function Alarm() {
-    const { alarmData } = fetchSSE();
+    const { alarmData } = fetchSSEHandler();
 
     return (
         <AlarmContainer>

--- a/src/views/Recipes/RecommendedRecipes/RecommendedRecipes.tsx
+++ b/src/views/Recipes/RecommendedRecipes/RecommendedRecipes.tsx
@@ -29,7 +29,7 @@ function RecommendedRecipes(): JSX.Element {
         try {
             const response = await instance.get('/recipes/recommended');
             if (response.data.code == 'OK') {
-                const data = response.data.data;
+                const data = response.data.data.recipes;
                 const convertData = data.map((item: RecipeProps) => ({
                     ...item,
                     recipeLevel: convertLevel(item.recipeLevel),


### PR DESCRIPTION
detailRecipe response 데이터 수정

- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?
- [ ] 💻 git rebase를 사용했나요?
- [ ] 🌈 알록달록한가요?

## 작업 내용
- SSE Init message는 string type으로 try-catch로 처리(alarmData에 저장x)
- 레시피 상세 페이지 : response.data.data.recipes로 수정

## 스크린샷

## 주의사항

Closes #{이슈 번호}
